### PR TITLE
fix: correct command id error string

### DIFF
--- a/DatingSimMVP/Assets/Game/Application/Commands/CommandService.cs
+++ b/DatingSimMVP/Assets/Game/Application/Commands/CommandService.cs
@@ -56,7 +56,7 @@ namespace Game.Application.Commands
         public void SelectWeekdayCommand(string id)
         {
             if (_catalog == null || !_catalog.ContainsKey(id))
-                throw new ArgumentException("$Unknown command id '{id}'");
+                throw new ArgumentException($"Unknown command id '{id}'");
             _currentCommand = id;
         }
 


### PR DESCRIPTION
## Summary
- fix malformed interpolation in `CommandService` for unknown command id

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25f735924832593136f101d44a4f8